### PR TITLE
Add an except AttributeError catch in BaseSerializer.object_to_data

### DIFF
--- a/r2dto/fields.py
+++ b/r2dto/fields.py
@@ -117,19 +117,18 @@ class ListField(BaseField):
 
     def object_to_data(self, obj):
         res = []
+        errors = []
         for item_i, item in enumerate(obj):
             for allowed_type in self.allowed_types:
                 try:
                     data = allowed_type.object_to_data(item)
-                except ValidationError:
-                    pass
+                except ValidationError as ex:
+                    errors.append('{}[{}]: {}'.format(self.name, item_i, ex))
                 else:
                     res.append(data)
                     break
-            else:
-                raise InvalidTypeValidationError(
-                    "{}[{}]".format(self.name, item_i), str(self.allowed_types), type(item)
-                )
+        if errors:
+            raise ValidationError(errors)
         return res
 
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -130,8 +130,8 @@ class AcceptanceTests(unittest.TestCase):
             self.fail('No Exception was thrown, object should have failed validation')
         except ValidationError as ex:
             self.assertEqual("subObjs[0]: ['Field field is missing from object.']", ex.errors[0])
-            self.assertEqual('subObjs[1]: ["field must be a (<type \'basestring\'>,).  Got <type \'int\'>."]',
-                             ex.errors[1])
+            self.assertEqual('subObjs[1]: ["field must be a (<class \'str\'>,).  Got <class \'int\'>."]',
+                             ex.errors[1].replace('type', 'class').replace('basestring', 'str'))
 
     def test_list_failure(self):
         class ObjSerializer(Serializer):


### PR DESCRIPTION
- Add a default_model method to the BaseSerializer  
  - This method initializes the model class and validates the fields in the model. Previously the model was not validated but was then used for missing fields in the data_to_object() method. This could potentially cause errors if the model is bad
  - Required field validation is not performed on the model as these fields "MUST" be in the data being serialized/deserialized. Any scenario in which required fields are not in the obj or data being serialized will throw an error before the default model is validated.
- Add an except AttributeError catch in BaseSerializer.object_to_data. 
  - This should fix a bug where an object does not have a non-required field(s) but during deserialization raises an AttributeError. object_to_data now behaves more like data_to_object with regards to non-required fields. 
  - Non-required fields when missing in the data being serialized/deserialized will use default model fields instead. If this is not the desired behavior then make sure to not set a model in the serializer. This was the default behavior of data_to_object.
- Fixed an issue with cryptic validation error message regarding Objects in a List Fields.
