### PR TITLE
Fix for the List field with several allowed types provided.

### DIFF
--- a/r2dto/fields.py
+++ b/r2dto/fields.py
@@ -104,14 +104,17 @@ class ListField(BaseField):
         res = []
         errors = []
         for item_i, item in enumerate(data):
+            item_errors = list()
             for allowed_type in self.allowed_types:
                 try:
                     obj = allowed_type.clean(item)
                 except ValidationError as ex:
-                    errors.append('{}[{}]: {}'.format(self.name, item_i, ex))
+                    item_errors.append('{}[{}]: {}'.format(self.name, item_i, ex))
                 else:
                     res.append(obj)
+                    item_errors = list()
                     break
+            errors.extend(item_errors)
         if errors:
             raise ValidationError(errors)
         return res
@@ -120,14 +123,17 @@ class ListField(BaseField):
         res = []
         errors = []
         for item_i, item in enumerate(obj):
+            item_errors = list()
             for allowed_type in self.allowed_types:
                 try:
                     data = allowed_type.object_to_data(item)
                 except ValidationError as ex:
-                    errors.append('{}[{}]: {}'.format(self.name, item_i, ex))
+                    item_errors.append('{}[{}]: {}'.format(self.name, item_i, ex))
                 else:
                     res.append(data)
+                    item_errors = list()
                     break
+            errors.extend(item_errors)
         if errors:
             raise ValidationError(errors)
         return res


### PR DESCRIPTION
Without this fix the List field validation fails if validation fails for the  first item of the 'allowed_types' items. Such a behaviour probably makes the 'allowed_types' parameter not useful for List fields at all.